### PR TITLE
fix variable initialization

### DIFF
--- a/startnb.sh
+++ b/startnb.sh
@@ -100,7 +100,6 @@ img=${img:-$NBIMG}
 
 OS=$(uname -s)
 MACHINE=$(uname -m) # Linux and macos x86
-QEMU="qemu-system-${MACHINE}"
 
 cputype="host"
 
@@ -131,6 +130,8 @@ OpenBSD)
 *)
 	echo "Unknown hypervisor, no acceleration"
 esac
+
+QEMU="qemu-system-${MACHINE}"
 
 mem=${mem:-"256"}
 cores=${cores:-"1"}


### PR DESCRIPTION
The variable `MACHINE` is used to define the `QEMU`

This patch defines `QEMU` **after** `MACHINE` is changed (when running on MacOS for example)