### PR TITLE
feat: print which mandatory option is missing

### DIFF
--- a/startnb.sh
+++ b/startnb.sh
@@ -78,7 +78,13 @@ done
 kernel=${kernel:-$KERNEL}
 img=${img:-$NBIMG}
 
-[ -z "$kernel" -o -z "$img" ] && usage
+if [ -z "$kernel" -o -z "$img" ]; then
+	echo "" 1>&2
+	[ -z "$kernel" ] && echo "'kernel' is not defined" 1>&2
+	[ -z "$img" ] && echo "'image' is not defined" 1>&2
+	echo "" 1>&2
+	usage
+fi
 
 [ -n "$hostfwd" ] && network="\
 -device virtio-net-device,netdev=net${uuid}0 \


### PR DESCRIPTION
Hey there! \o

I made this PR so that the startnb.sh script indicates which mandatory option is missing.
It can be useful when a configuration file references a variable which is not defined.