### PR TITLE
fix: edit and delete buttons are disabled only if editprotect and rmprotect are 'True'

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -77,10 +77,10 @@
                 {{ vm.status === 'running' ? 'stop' : 'start' }}
               </button>
               <button class="btn btn-sm btn-light me-2"
-                :disabled="vm.editprotect"
+                :disabled="vm.editprotect==='True'"
 		@click="editVM(vmName)">✏️</button>
               <button class="btn btn-sm btn-light me-2"
-                :disabled="vm.rmprotect"
+                :disabled="vm.rmprotect==='True'"
                 @click="deleteVM(vmName)">🗑️</button>
               <button class="btn btn-sm btn-light me-2"
                 :disabled="!vm.serial_port"


### PR DESCRIPTION
Before this fix, if a configuration file contains the following lines :

```
editprotect=plop
rmprotect=what
```

Both buttons (edit and delete) will be disabled.

This patch fixes this by checking that the value of those fields is equal to `True`