### PR TITLE
Minor: Add instructions on how to install bsdtar on linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Warning those are _NetBSD-current_ kernels!
   - `sudo` or `doas`
   - `rsync`
   - `nm`
-  - `bsdtar`
+  - `bsdtar` (install with libarchive-tools on linux)
 - A x86 VT-capable, or ARM64 CPU is recommended
 
 ## Project structure


### PR DESCRIPTION
I add a bit of troubles finding how to get bsdtar until I read the github workflow, I think it could help others to have the package to install on linux to get bsdtar available.