### PR TITLE
feat: added support for hostfwd connection type selection

### DIFF
--- a/startnb.sh
+++ b/startnb.sh
@@ -91,7 +91,7 @@ fi
 
 [ -n "$hostfwd" ] && network="\
 -device virtio-net-device,netdev=net${uuid}0 \
--netdev user,id=net${uuid}0,ipv6=off,$(echo "$hostfwd"|sed 's/::/hostfwd=::/g')"
+-netdev user,id=net${uuid}0,ipv6=off,$(echo "$hostfwd"|sed -E 's/(udp|tcp)?::/hostfwd=\1::/g')"
 
 [ -n "$bridgenet" ] && network="$network \
 -device virtio-net-device,netdev=net${uuid}1 \


### PR DESCRIPTION
Qemu hostfwd default connection type is TCP. With the current sed expression, it's not possible to specify the connection type. This means it's not possible to create a UDP service.

This PR should fix this by allowing to specify `tcp` or `udp`.

From what I've tested the following will work as expected:

```
$ echo "::80-:8080"|sed -E 's/(udp|tcp)?::/hostfwd=\1::/g'                                                                                                                                                       
hostfwd=::80-:8080

$ echo "tcp::80-:8080"|sed -E 's/(udp|tcp)?::/hostfwd=\1::/g'                                                                                                                                                    
hostfwd=tcp::80-:8080

$ echo "udp::53-:5353"|sed -E 's/(udp|tcp)?::/hostfwd=\1::/g'                                                                                                                                                    
hostfwd=udp::80-:8080
```