### PR TITLE
discussion

### DIFF
--- a/startnb.sh
+++ b/startnb.sh
@@ -165,7 +165,7 @@ x86_64|i386)
 	cpuflags="-cpu ${cputype},+invtsc"
 	root=${root:-"ld0a"}
 	# stack smashing with version 9.0 and 9.1
-	${QEMU} --version|egrep -q '9\.[01]' && \
+	${QEMU} --version| grep -q -E '9\.[01]' && \
 		extra="$extra -L bios -bios bios-microvm.bin"
 	;;
 aarch64)


### PR DESCRIPTION
This is just to know... if just one version is impacted (I'm running qemu-x86_64 version 10.1.0)

Not sure to have the skills but I'd like to understand
I noticed that

nm kernels/netbsd-SMOL | grep -q viocon_earlyinit              => 0
but
nm kernels/netbsd-MICROVM | grep -q viocon_earlyinit      => 1

