### PR TITLE
Add missing folder and packages

### DIFF
--- a/docs/yt-scripts/20250920 - LutinOS 0.0.md
+++ b/docs/yt-scripts/20250920 - LutinOS 0.0.md
@@ -4,8 +4,8 @@
 ⚠ This is for educational purpose only, an automated `nitro` based image creation is available in the `services/` directory.
 
 ```bash
-$ sudo apt install libarchive-tools # for bsdtar
-$ mkdir kernels mnt pkgs
+$ sudo apt install libarchive-tools rsync qemu-system-x86 # for bsdtar
+$ mkdir kernels mnt pkgs images
 $ curl -L -o - -s https://nycdn.netbsd.org/pub/NetBSD-daily/netbsd-11/20250916040529Z/amd64/binary/kernel/netbsd-MICROVM.gz | gunzip -c > kernels/netbsd-MICROVM # download a MICROVM kernel
 $ make MOUNTRO=y base # create a read-only base image (base-amd64.img)
 $ mv base-amd64.img images/frankenbase.img # create image/frankenbase.img


### PR DESCRIPTION
In the instructions for a person who start from scratch , he must install rsync and qemu-system-x86.
The folder images is not create and instruction mv base-amd64.img images/frankenbase.img doesn't work .

Totoy40 :)