### PR TITLE
Replace uuidgen with standard UNIX tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Warning those are _NetBSD-current_ kernels!
   - `curl`
   - `git`
   - `make` (`bmake` if running on Linux or MacOS)
-  - `uuid-runtime` (for uuidgen)
   - `qemu-system-x86_64`, `qemu-system-i386` or `qemu-system-aarch64`
   - `sudo` or `doas`
   - `nm`

--- a/startnb.sh
+++ b/startnb.sh
@@ -33,12 +33,6 @@ _USAGE_
 	exit 1
 }
 
-which uuidgen 1>/dev/null
-if [ $? -eq 1 ]; then
-	echo "uuidgen not available"
-	exit 1
-fi
-
 # Check if VirtualBox VM is running
 if pgrep VirtualBoxVM >/dev/null 2>&1; then
 	echo "Unable to start KVM: VirtualBox is running"
@@ -47,7 +41,7 @@ fi
 
 options="f:k:a:p:i:m:n:c:r:l:p:w:x:t:hbdsv"
 
-uuid="$(uuidgen | cut -d- -f1)"
+uuid="$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c8)"
 
 # and possibly override its values
 while getopts "$options" opt


### PR DESCRIPTION
By requiring fewer dependencies, we make the project easier to install and setup across many platforms.

LC_ALL=C parameter is passed to ensure POSIX compat.

Tested on Debian 6.12.48-1 and MacOS Darwin Kernel Version 25.0.0.