### PR TITLE
fix: trying dynamic images paths and names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ KDIST=		https://smolbsd.org/assets
 LIVEIMGGZ=	https://nycdn.netbsd.org/pub/NetBSD-daily/HEAD/latest/images/NetBSD-11.99.3-amd64-live.img.gz
 .endif
 
-LIVEIMG=	NetBSD-${ARCH}-live.img
+LIVEIMG=	images/NetBSD-${ARCH}-live.img
 
 # sets to fetch, defaults to base
 SETS?=		base.${SETSEXT} etc.${SETSEXT}

--- a/etc/bozohttpd.conf
+++ b/etc/bozohttpd.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=bozohttpd
 # mandatory
-img=bozohttpd-amd64.img
+img=images/bozohttpd-$img_arch.img
 # mandatory
-kernel=kernels/netbsd-SMOL
+kernel=kernels/$kernel_name
 # optional
 mem=128m
 # optional

--- a/etc/live.conf
+++ b/etc/live.conf
@@ -1,9 +1,9 @@
-ARCH="$(uname -m)"
+# mandatory
 vm=live
 # make live for amd64 or make ARCH=evbarm-aarch64 live
-img=NetBSD-$([ "$ARCH" = "x86_64" ] && echo amd64 || echo evbarm-aarch64)-live.img
+img=images/NetBSD-$img_arch-live.img
 # netbsd-SMOL for amd64 or netbsd-GENERIC64.img for aarch64
-kernel=netbsd-$([ "$ARCH" = "x86_64" ] && echo SMOL || echo GENERIC64.img)
+kernel=kernels/$kernel_name
 mem=1g
 cores=2
 hostfwd=::22222-:22

--- a/etc/nbakery.conf
+++ b/etc/nbakery.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=nbakery
 # mandatory
-img=nbakery-amd64.img
+img=images/nbakery-$img_arch.img
 # mandatory
-kernel=kernels/netbsd-SMOL
+kernel=kernels/$kernel_name
 # optional
 mem=512m
 # optional

--- a/etc/nitrosshd.conf
+++ b/etc/nitrosshd.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=nitrosshd
 # mandatory
-img=nitrosshd-amd64.img
+img=images/nitrosshd-$img_arch.img
 # mandatory
-kernel=kernels/netbsd-SMOL
+kernel=kernels/$kernel_name
 # optional
 mem=256m
 # optional

--- a/etc/rescue.conf
+++ b/etc/rescue.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=rescue
 # mandatory
-img=$NBIMG
+img=images/rescue-$img_arch.img
 # mandatory
-kernel=$KERNEL
+kernel=kernels/$kernel_name
 # optional
 mem=128m
 # optional

--- a/etc/runbsd.conf
+++ b/etc/runbsd.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=runbsd
 # mandatory
-img=$NBIMG
+img=images/runbsd-$img_arch.img
 # mandatory
-kernel=$KERNEL
+kernel=kernels/$kernel_name
 # optional
 mem=512m
 # optional

--- a/etc/sshd.conf
+++ b/etc/sshd.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=sshd
 # mandatory
-img=sshd-amd64.img
+img=sshd-$img_arch.img
 # mandatory
-kernel=kernels/netbsd-SMOL
+kernel=kernels/$kernel_name
 # optional
 mem=256m
 # optional

--- a/etc/systembsd.conf
+++ b/etc/systembsd.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=systembsd
 # mandatory
-img=$NBIMG
+img=images/systembsd-$img_arch.img
 # mandatory
-kernel=$KERNEL
+kernel=kernels/$kernel_name
 # optional
 mem=512m
 # optional

--- a/etc/tslog.conf
+++ b/etc/tslog.conf
@@ -1,9 +1,9 @@
-# optional vm name, used in pidfile
+# mandatory
 vm=tslog
 # mandatory
-img=$(pwd)/images/tslog-amd64.img
+img=$(pwd)/images/tslog-$img_arch.img
 # mandatory
-kernel=$KERNEL
+kernel=kernels/$kernel_name
 # optional
 mem=256m
 # optional


### PR DESCRIPTION
If the good approach is to use the builder, images are now created in the `images` folder, so at least prepeding it in conf files was legit... But I didn't managed to stay shy, nor to test the whole thing yet on all architectures, so please review carefully ;)