### PR TITLE
Fix freshchk.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,10 @@ help:	# This help you are reading
 kernfetch:
 	$Qmkdir -p kernels
 	$Qif [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ]; then \
-		${FRESHCHK} ${KDIST}/${KERNEL} || \
+		${FRESHCHK} ${KDIST}/${KERNEL} kernels/${KERNEL} || \
 			${FETCH} -o kernels/${KERNEL} ${KDIST}/${KERNEL}; \
 	else \
-		${FRESHCHK} ${KDIST}/kernel/${KERNEL}.gz || \
+		${FRESHCHK} ${KDIST}/kernel/${KERNEL}.gz kernels/${KERNEL} || \
 			curl -L -o- ${KDIST}/kernel/${KERNEL}.gz | \
 				gzip -dc > kernels/${KERNEL}; \
 	fi
@@ -123,14 +123,14 @@ kernfetch:
 setfetch:
 	@[ -d ${SETSDIR} ] || mkdir -p ${SETSDIR}
 	$Qfor s in ${SETS}; do \
-		${FRESHCHK} ${DIST}/sets/$${s} || \
+		${FRESHCHK} ${DIST}/sets/$${s} ${SETSDIR}/$${s} || \
 			${FETCH} -o ${SETSDIR}/$${s} ${DIST}/sets/$${s}; \
 	done
 
 pkgfetch:
 	@[ -d ${PKGSDIR} ] || mkdir -p ${PKGSDIR}
 	$Qfor p in ${ADDPKGS};do \
-		${FRESHCHK} ${PKGSITE}/$${p}* || \
+		${FRESHCHK} ${PKGSITE}/$${p}* ${PKGSDIR}/$${p}.tgz || \
 			${FETCH} -o ${PKGSDIR}/$${p}.tgz ${PKGSITE}/$${p}*; \
 	done
 

--- a/scripts/freshchk.sh
+++ b/scripts/freshchk.sh
@@ -6,6 +6,7 @@
 . service/common/choupi
 
 URL=$1
+DEST=$2
 FILE=${1##*://}
 FILE=${FILE%\*} # clean wildcard from http://foo/bar* URL
 DIR=${FILE%/*}
@@ -18,7 +19,7 @@ remotefile=$($FETCH -I $URL | \
 	base64 || echo 0)
 localfile=$(cat db/$FILE 2>/dev/null || echo 0)
 
-if [ "$remotefile" = "$localfile" ]; then
+if [ -s "${DEST}" ] && [ "$remotefile" = "$localfile" ]; then
 	echo "${CHECK} ${FILE##*/} is fresh"
 	exit 0
 fi


### PR DESCRIPTION
With the current implementation of `scripts/freshchk.sh`, you can do the following :
```
# Starting fresh ;)
$ rm -rf db/ kernels/

# Download a kernel
$ bmake kernfetch
➡️ fetching netbsd-GENERIC64.img.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   231  100   231    0     0   2732      0 --:--:-- --:--:-- --:--:--  2717
100 6826k  100 6826k    0     0  9484k      0 --:--:-- --:--:-- --:--:-- 9484k

# Deleting the downloaded kernel
$ rm kernels/netbsd-GENERIC64.img

# Trying to download it again
$ bmake kernfetch
✅ netbsd-GENERIC64.img.gz is fresh
$
```

This PR adds a second `DEST` argument to `scripts/freshchk.sh` so that it can fail if the destination file is not present or is empty.

This PR also fixes a small syntax issue in `Makefile` (the missing `;` prevents the execution of the `else` branch)