### PR TITLE
app: Update openSerialPort() to open external telnet to VM

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -84,6 +84,7 @@
                 :disabled="vm.rmprotect==='True'"
                 @click="deleteVM(vmName)">🗑️</button>
               <button class="btn btn-sm btn-light me-2"
+                title="telnet to Virtual Machine TCP serial port"
                 :disabled="!vm.serial_port"
                 @click="openSerialPort(vmName)">💻</button>
             </div>


### PR DESCRIPTION
This fixes the problem that the windows.close() in `openSerialPort()` will close the window asking for permission to open external telnet:// links, before the user has time to confirm