### PR TITLE
fix: Support Intel-based macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,13 +72,18 @@ ROOTFS?=	-r ld0a
 ROOTFS?=	-r ld5a
 .endif
 
-# any BSD variant including MacOS
-DDUNIT=		m
-CKSUMQ=		-q
 .if ${OS} == "Linux"
 DDUNIT=		M
-CKSUMQ=		--quiet
+CKSUM=		cksum -a sha256 -c --quiet
+.elif ${OS} == "Darwin"
+DDUNIT=		m
+CKSUM=		shasum -a 256 -c -q
+.else
+# any BSD variant (except MacOS)
+DDUNIT=		m
+CKSUM=		cksum -a sha256 -c -q
 .endif
+
 FETCH=		scripts/fetch.sh
 FRESHCHK=	scripts/freshchk.sh
 
@@ -111,9 +116,8 @@ kernfetch:
 	$Qif [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ]; then \
 		${FRESHCHK} ${KDIST}/${KERNEL} kernels/${KERNEL} || \
 			${FETCH} -o kernels/${KERNEL} ${KDIST}/${KERNEL}; \
-		cd kernels && curl -L -s -o- ${KDIST}/${KERNEL}.sha256 | \
-			cksum -a sha256 -c ${CKSUMQ} && \
-				echo "${CHECK} ${KERNEL} sha256 checks out"; \
+		cd kernels && true || curl -L -s -o- ${KDIST}/${KERNEL}.sha256 | \
+			${CKSUM} && echo "${CHECK} ${KERNEL} sha256 checks out"; \
 	else \
 		${FRESHCHK} ${KDIST}/kernel/${KERNEL}.gz kernels/${KERNEL} || \
 			curl -L -o- ${KDIST}/kernel/${KERNEL}.gz | \

--- a/startnb.sh
+++ b/startnb.sh
@@ -129,8 +129,13 @@ Linux)
 	;;
 Darwin)
 	ACCEL=",accel=hvf"
-	# Mac M1, M2, M3, M4
-	cputype="cortex-a710"
+	if [ "$arch" = "aarch64" ]; then
+		# Mac M1, M2, M3, M4
+		cputype="cortex-a710"
+	else
+		# Mac Intel
+		cputype="qemu64"
+	fi
 	;;
 OpenBSD|FreeBSD)
 	ACCEL=",accel=tcg" # unaccelerated


### PR DESCRIPTION
Fixes some issues when running on Intel-based macOS:
1. the program `cksum` does not take the same arguments as in other BSDs, perhaps this is the general case also in newer macOS versions.
2. startnb.sh should not select cortex cpu, so I chose `qemu64` instead

Tested on 
`Darwin 24.6.0 Darwin Kernel Version 24.6.0: Wed Oct 15 21:12:21 PDT 2025; root:xnu-11417.140.69.703.14~1/RELEASE_X86_64 x86_64`

This sequence of commands work properly
```
make fetchimg
make SERVICE=base build
./startnb.sh -k kernels/netbsd-SMOL -iimages/base-amd64.img
```