### PR TITLE
fix cputype on MacOS

### DIFF
--- a/startnb.sh
+++ b/startnb.sh
@@ -130,7 +130,7 @@ Linux)
 Darwin)
 	accel="-accel hvf"
 	# Mac M1, M2, M3, M4
-	cputype="cortex-a710"
+	cputype="cortex-a57"
 	;;
 OpenBSD|FreeBSD)
 	accel="-accel tcg" # unaccelerated


### PR DESCRIPTION
This PR closes #57 

This should be tested with other qemu versions to be sure it doesn't break with older versions